### PR TITLE
feat: add JAVA_OPTS configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "kotlin.java.opts": {
           "type": "string",
           "default": "",
-          "description": "Custom options using JAVA_OPTS for the language server and debug adapter."
+          "description": "Custom options using JAVA_OPTS for the language server."
         },
         "kotlin.languageServer.enabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
     "configuration": {
       "title": "Kotlin",
       "properties": {
+        "kotlin.java.opts": {
+          "type": "string",
+          "default": "",
+          "description": "Custom options using JAVA_OPTS for the language server and debug adapter."
+        },
         "kotlin.languageServer.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/languageSetup.ts
+++ b/src/languageSetup.ts
@@ -62,7 +62,12 @@ export async function activateLanguageServer(
 
   const transportLayer = config.get('languageServer.transport');
   let tcpPort: number | undefined = undefined;
-  const env: any = undefined;
+  const env: any = { ...process.env };
+
+  const javaOpts = config.get<string>('java.opts');
+  if (javaOpts) {
+    env['JAVA_OPTS'] = javaOpts;
+  }
 
   if (transportLayer === 'tcp') {
     tcpPort = config.get<number>('languageServer.port')!;


### PR DESCRIPTION
This PR try to make it super easy for people to be able to configure their Java options by need. Like this:

```
{
  "kotlin.java.opts": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx4G -Xms4G -Xlog:disable",
}
```

This is useful for development with big repository.

Alternatively, user environment variables would also work just fine.